### PR TITLE
修正了部分ch55x系列芯片的参数

### DIFF
--- a/devices/0x11-CH55x.yaml
+++ b/devices/0x11-CH55x.yaml
@@ -79,20 +79,20 @@ variants:
     chip_id: 0x51
     flash_size: 10K
     eeprom_size: 128
-    eeprom_start_addr: 0x2800
+    eeprom_start_addr: 0xC000
 
   - name: CH552
     chip_id: 0x52
     # FIXME: 16K or 14K
     flash_size: 14K
     eeprom_size: 128
-    eeprom_start_addr: 14K
+    eeprom_start_addr: 0xC000
 
   - name: CH554
     chip_id: 0x54
     flash_size: 14K
     eeprom_size: 128
-    eeprom_start_addr: 14K
+    eeprom_start_addr: 0xC000
 
   - name: CH555
     chip_id: 0x55
@@ -116,7 +116,7 @@ variants:
     chip_id: 0x58
     flash_size: 32768
     eeprom_size: 5120
-    eeprom_start_addr: 61440
+    eeprom_start_addr: 0xE000
 
   - name: CH559
     chip_id: 0x59


### PR DESCRIPTION
修正了ch551/2/4的eeprom_start_addr
【#define DATA_FLASH_ADDR   0xC000    // start address of Data-Flash】from CH552.H 同样适用于ch551
【#define DATA_FLASH_ADDR   0xC000    // start address of Data-Flash】from CH554.H
【#define DATA_FLASH_ADDR   0xE000    // start address of Data-Flash】from CH558.H