### PR TITLE
Added second vendor id 1a86

### DIFF
--- a/src/transport/usb.rs
+++ b/src/transport/usb.rs
@@ -25,7 +25,7 @@ impl UsbTransport {
             .filter(|device| {
                 device
                     .device_descriptor()
-                    .map(|desc| desc.vendor_id() == 0x4348 && desc.product_id() == 0x55e0)
+                    .map(|desc| (desc.vendor_id() == 0x4348 || desc.vendor_id() == 0x1a86) && desc.product_id() == 0x55e0)
                     .unwrap_or(false)
             })
             .enumerate()
@@ -45,7 +45,7 @@ impl UsbTransport {
             .filter(|device| {
                 device
                     .device_descriptor()
-                    .map(|desc| desc.vendor_id() == 0x4348 && desc.product_id() == 0x55e0)
+                    .map(|desc| (desc.vendor_id() == 0x4348 || desc.vendor_id() == 0x1a86) && desc.product_id() == 0x55e0)
                     .unwrap_or(false)
             })
             .nth(nth)

--- a/src/transport/usb.rs
+++ b/src/transport/usb.rs
@@ -50,7 +50,7 @@ impl UsbTransport {
             })
             .nth(nth)
             .ok_or(anyhow::format_err!(
-                "No WCH ISP USB device found(4348:55e0 device not found at index #{})",
+                "No WCH ISP USB device found(4348:55e0 or 1a86:55e0 device not found at index #{})",
                 nth
             ))?;
         log::debug!("Found USB Device {:?}", device);


### PR DESCRIPTION
It seems that WCH uses two vendor ids but wchisp only used 0x4348. I have tested with a CH32X035F8U6 device with the vendor id 1a86.