### PR TITLE
Update README.md - update WeAct Studio CH592F

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ This tool should work on most WCH MCU chips. But I haven't tested it on any othe
 - [x] CH573
   - [WeAct Studio CH573F](https://github.com/WeActStudio/WeActStudio.WCH-BLE-Core/blob/master/Images/1.png)
 - [x] CH592
-  - [WeActStudio.WCH-BLE-Core](https://github.com/WeActStudio/WeActStudio.WCH-BLE-Core)
-  - [WeAct CH592F BLE5.4 Mini Core](https://www.aliexpress.com/item/1005006117859297.html)
+  - [WeAct Studio CH592F](https://github.com/WeActStudio/WeActStudio.WCH-BLE-Core/blob/master/Images/2.png)
 - [x] CH579
   - BTVER: 02.90 #18
 - [x] CH559


### PR DESCRIPTION
The CH592F device was added twice in the list with two different links. Also providing shopping links instead of general links to the device can be seen as advertisement. Now all 3 WeAct boards are listed properly in the readme.