### PR TITLE
ch57xf reset value fix, CFG_ROM_READ=0

### DIFF
--- a/devices/0x13-CH57x.yaml
+++ b/devices/0x13-CH57x.yaml
@@ -36,9 +36,9 @@ config_registers_ch571_ch573: &config_registers_ch571_ch573
     name: USER_CFG
     description: User config register
     # reset: 0x4FFF0F4D
-    # CFG_DEBUG_EN=1、CFG_RESET_EN=0、CFG_ROM_READ=1
+    # CFG_DEBUG_EN=1、CFG_RESET_EN=0、CFG_ROM_READ=0
     # enable 2-wire debug
-    reset: 0x4FFF0FD5
+    reset: 0x4FFF0F55
     type: u32
     fields:
       - bit_range: [2, 0]


### PR DESCRIPTION
I found that when CFG_ROM_READ is 1, then it is not possible flash ch571f/ch573f. Native WCHISPUtil has same behavior.