### PR TITLE
Add support for CH32V002/004/005/006/007

### DIFF
--- a/devices/0x21-CH32V00x.yaml
+++ b/devices/0x21-CH32V00x.yaml
@@ -5,9 +5,9 @@ device_type: 0x21
 support_net: false
 support_usb: false
 support_serial: true
-description: CH32V00x (RISC-V2A) Series
+description: CH32V00x (RISC-V2A/V2C) Series
 config_registers:
-  # Ref: section "16.5 User Option Bytes" of RM manual
+  # Ref: section 16.5 (CH32V003) & 18.5 (CH32V00x) "User Option Bytes" of RM manual
   - offset: 0x00
     name: RDPR_USER
     description: RDPR, nRDPR, USER, nUSER
@@ -16,7 +16,7 @@ config_registers:
     fields:
       - bit_range: [7, 0]
         name: RDPR
-        description: Read Protection. 0xA5 for unprotected, otherwise read-protected (ignoring WRP)
+        description: Read Protection. 0xA5 for unprotected, otherwise read-protected (ignoring WRPR)
         explaination:
           0xa5: Unprotected
           _: Protected
@@ -58,7 +58,9 @@ config_registers:
         name: DATA1
   - offset: 0x08
     name: WRPR
-    # Each bit is used to control the write-protect status of 1 sector (1K bytes/sector)
+    # Each bit is used to control the write-protect status of sectors as follows:
+    #   CH32V003: 1 sector (1K/sector), max 16K (WRPR3/4 reserved)
+    #   CH32V002/004/005/006/007: 2 sectors (1K/sector), max 64K
     description: Flash memory write protection status
     type: u32
     reset: 0xFFFFFFFF
@@ -66,16 +68,66 @@ config_registers:
       0xFFFFFFFF: Unprotected
       _: Some 1K sections are protected
 variants:
+  - name: CH32V002A4M6
+    chip_id: 0x22
+    flash_size: 16K
+  - name: CH32V002D4U6
+    chip_id: 0x23
+    flash_size: 16K
+  - name: CH32V002F4P6
+    chip_id: 0x20
+    flash_size: 16K
+  - name: CH32V002F4U6
+    chip_id: 0x21
+    flash_size: 16K
+  - name: CH32V002J4M6
+    chip_id: 0x24
+    flash_size: 16K
+  - name: CH32V003A4M6
+    chip_id: 0x32
+    flash_size: 16K
   - name: CH32V003F4P6
     chip_id: 0x30
     flash_size: 16K
   - name: CH32V003F4U6
     chip_id: 0x31
     flash_size: 16K
-  - name: CH32V003A4M6
-    chip_id: 0x32
-    flash_size: 16K
   - name: CH32V003J4M6
     chip_id: 0x33
     flash_size: 16K
-  # TODO: add CH32V002, 004 & 006 - chip IDs unknown at present
+  - name: CH32V004F6P1
+    chip_id: 0x40
+    flash_size: 32K
+  - name: CH32V004F6U1
+    chip_id: 0x41
+    flash_size: 32K
+  - name: CH32V005D6U6
+    chip_id: 0x53
+    flash_size: 32K
+  - name: CH32V005E6R6
+    chip_id: 0x50
+    flash_size: 32K
+  - name: CH32V005F6P6
+    chip_id: 0x52
+    flash_size: 32K
+  - name: CH32V005F6U6
+    chip_id: 0x51
+    flash_size: 32K
+  - name: CH32V006E8R6
+    chip_id: 0x61
+    flash_size: 62K
+  - name: CH32V006F8P6
+    chip_id: 0x63
+    flash_size: 62K
+  - name: CH32V006F8U6
+    chip_id: 0x62
+    flash_size: 62K
+  - name: CH32V006K8U6
+    chip_id: 0x60
+    flash_size: 62K
+  - name: CH32V007E8R6
+    chip_id: 0x71
+    flash_size: 62K
+  - name: CH32V007K8U6
+    chip_id: 0x72
+    flash_size: 62K

--- a/devices/0x21-CH32V00x.yaml
+++ b/devices/0x21-CH32V00x.yaml
@@ -131,3 +131,7 @@ variants:
   - name: CH32V007K8U6
     chip_id: 0x72
     flash_size: 62K
+  - name: CH32M007G8R6
+    chip_id: 0x70
+    flash_size: 62K
+  # TODO: add CH32M007E8R6, CH32M007E8U6 when chip IDs known.


### PR DESCRIPTION
This change adds support for CH32V002, CH32V004, CH32V005, CH32V006, CH32V007, and CH32M007.

Although I haven't been able to test against actual hardware (not yet found any chips or boards for sale - at least, not in Western marketplaces), I have verified the following:

* Type ID of `0x21` is same as '003, by capturing serial communication of WCHISPTool's '002 ident command.
* Chip IDs verified against list [here](https://github.com/openwch/ch32v002_004_005_006_007/blob/7cb39c4dd825f172578b30ce14821da44f8604c1/EVT/EXAM/SRC/Peripheral/src/ch32v00X_dbgmcu.c#L104) in WCH HAL code, and also WCHISPTool config file data.
* Option bytes are the same, by comparing reference manual info.

For CH32M007E8R6 and CH32M007E8U6, although they are listed in the '007 datasheet, I could not find out their chip IDs, so haven't added them.