### PR TITLE
Updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Command-line implementation of the WCHISPTool in Rust, by the ch32-rs team.
 
 This tool is a work in progress.
 
-- **NOTE**: CH32V003 **DOES NOT** have a USB ISP interface, use WCH-Link to program
-- **NOTE**: This tool is for USB ISP, not using with WCH-Link
-  - [ch32-rs/wlink](https://github.com/ch32-rs/wlink) is a command line tool for WCH-Link
+> [!NOTE]
+> This tool is for **USB** and **UART** ISP, not for use with WCH-Link.
+> - [ch32-rs/wlink](https://github.com/ch32-rs/wlink) is a command line tool for WCH-Link.
 
 ## Installing
 
 The prebuilt binaries are available on the [Nightly release page](https://github.com/ch32-rs/wchisp/releases/tag/nightly).
 
-For Windows users, you will need vc runtime to run the binary. You can download it from [Microsoft](https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170).
+For Windows users, you will need VC runtime to run the binary. You can download it from [Microsoft](https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170).
 
 Or else, you can install it from source.
 
@@ -56,10 +56,13 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="4348", ATTRS{idProduct}=="55e0", MODE="0666"
 ### Arch Linux
 
 Arch Linux users can install [wchisp](https://aur.archlinux.org/packages/wchisp) or [wchisp-git](https://aur.archlinux.org/packages/wchisp-git) via the AUR.
+
 ```bash
 yay wchisp
 ```
+
 or
+
 ```bash
 yay wchisp-git
 ```
@@ -96,6 +99,12 @@ WRP: 0xFFFFFFFF
 > wchisp config reset
 ```
 
+### CH32V00x Notes
+
+The CH32V00x series **DOES NOT** have a USB ISP interface; it can only be accessed via UART. Use `-s` or `--serial` command-line option to specify serial transport, and `-p` or `--port` option to specify COM/TTY port.
+
+Also note that ISP bootloader entry cannot be controlled via external pin state at reset. Instead, user application code must instruct device to enter the bootloader via setting `FLASH_STATR.MODE` flag and performing a software reset (see `PFIC_CFGR`).
+
 ## Tested On
 
 This tool should work on most WCH MCU chips. But I haven't tested it on any other chips.
@@ -124,6 +133,8 @@ This tool should work on most WCH MCU chips. But I haven't tested it on any othe
 - [x] CH32V203
   - [CH32V203G6 FlappyBoard](https://github.com/metro94/FlappyBoard)
   - [nanoCH32V203](https://github.com/wuxx/nanoCH32V203)
+- [x] CH32V003
+- [x] CH32X035
 - ... (feel free to open an issue whether it works on your chip or not)
 
 ## TODOs
@@ -144,8 +155,9 @@ This tool should work on most WCH MCU chips. But I haven't tested it on any othe
 - [x] EEPROM dump
 - [x] EEPROM erase
 - [x] EEPROM write
-- [x] select from multiple chips(using `-d` to select device index) `wchisp -d 0 info`
-- [ ] ISP via UART or Net
+- [x] select from multiple chips (using `-d` to select device index) `wchisp -d 0 info`
+- [x] ISP via UART
+- [ ] ISP via Net
 
 ## Related Works (Many Thanks!)
 
@@ -164,6 +176,6 @@ If it works for your devices, please open a pull request to modify this README p
 
 It it doesn't, please open an issue. Better provide the following information:
 
-- chip type (with variant surfix)
-- debug print of usb packets
-- correct usb packets to negotiate with the chip (via USBPcap or other tools)
+- Chip type (with variant suffix).
+- Debug print of USB packets.
+- Correct USB packets to negotiate with the chip (via USBPcap or other tools).

--- a/devices/0x23-CH32X03x.yaml
+++ b/devices/0x23-CH32X03x.yaml
@@ -16,7 +16,7 @@ config_registers:
     fields:
       - bit_range: [7, 0]
         name: RDPR
-        description: Read Protection. 0xA5 for unprotected, otherwise read-protected(ignoring WRP)
+        description: Read Protection. 0xA5 for unprotected, otherwise read-protected (ignoring WRPR)
         explaination:
           0xa5: Unprotected
           _: Protected
@@ -32,18 +32,18 @@ config_registers:
         name: STOP_RST
         description: System reset control under the stop mode
         explaination:
-          1: Disable
-          0: Enable
+          1: Disabled
+          0: Enabled
       # [2:2] + 16
       - bit_range: [18, 18]
         name: STANDBY_RST
-        description: System reset control under the standby mode, STANDY_RST
+        description: System reset control under the standby mode
         explaination:
-          1: Disable, entering standby-mode without RST
-          0: Enable
+          1: Disabled, entering standby-mode without RST
+          0: Enabled
       # [4:3] + 16
       - bit_range: [20, 19]
-        name: RST_MOD
+        name: RST_MODE
         description: Reset mode
         explaination:
           0b00: Enable RST alternative function
@@ -60,14 +60,14 @@ config_registers:
       - bit_range: [23, 16]
         name: DATA1
   - offset: 0x08
-    name: WRP
-    # Each bit represents 4K bytes (16 pages) to store the write protection status
+    name: WRPR
+    # Each bit is used to control the write-protect status of 2 sectors (1K/sector), max 64K
     description: Flash memory write protection status
     type: u32
     reset: 0xFFFFFFFF
     explaination:
       0xFFFFFFFF: Unprotected
-      _: Some 4K sections are protected
+      _: Some 1K sectors are protected
 variants:
   - name: CH32X035R8T6
     chip_id: 80
@@ -90,4 +90,3 @@ variants:
   - name: CH32X033F8P6
     chip_id: 90 # 0x5a
     flash_size: 62K
-


### PR DESCRIPTION
I have made some updates to the README to correct out-of-date information:

* Add CH32V003 and CH32X035 to tested devices list (tested and confirmed working myself).
* Move note about CH32V00x being non-USB to dedicated usage sub-section, and add info about invoking bootloader.
* Correct various spelling and grammar.

I also corrected some things I noticed were wrong in the CH32X03x device info:

* Typos/spelling of names and descriptions.
* Flash uses 1k sectors, not 4k.

Or might you prefer that in a separate PR?