### PR TITLE
Add CH32V203 G8R6 variant

### DIFF
--- a/devices/0x19-CH32V20x.yaml
+++ b/devices/0x19-CH32V20x.yaml
@@ -109,3 +109,6 @@ variants:
     alt_chip_ids: [0x39]
     flash_size: 32K
   # FIXME: missing 0x38
+  - name: CH32V203G8R6
+    chip_id: 0x3b
+    flash_size: 64K


### PR DESCRIPTION
I’m using this variant in my devboard, which works after simply adding the variant to the list. It has 64K flash, as per datasheet.