### PR TITLE
Fix CH584 and CH585 DataFlash size to 32KB

### DIFF
--- a/devices/0x16-CH58x.yaml
+++ b/devices/0x16-CH58x.yaml
@@ -105,11 +105,11 @@ variants:
   - name: CH584
     chip_id: 0x84
     flash_size: 448K
-    eeprom_size: 96K
+    eeprom_size: 32K
     eeprom_start_addr: 458752
 
   - name: CH585
     chip_id: 0x85
     flash_size: 448K
-    eeprom_size: 128K
+    eeprom_size: 32K
     eeprom_start_addr: 458752


### PR DESCRIPTION
- Updated CH584 EEPROM size from 96KB to 32KB
- Updated CH585 EEPROM size from 128KB to 32KB
- Both changes match the official memory mapping documentation