### PR TITLE
Add support for CH32V317

### DIFF
--- a/devices/0x26-CH32V317.yaml
+++ b/devices/0x26-CH32V317.yaml
@@ -71,6 +71,6 @@ variants:
   - name: CH32V317WCU6
     chip_id: 0x73
     flash_size: 256K
-  - name: CH32V307VCT6
+  - name: CH32V317VCT6
     chip_id: 0x70
     flash_size: 256K

--- a/devices/0x26-CH32V317.yaml
+++ b/devices/0x26-CH32V317.yaml
@@ -1,0 +1,76 @@
+---
+name: CH32V317 Series
+mcu_type: 0x16
+device_type: 0x26
+support_net: false
+support_usb: true
+support_serial: true
+description: CH32V317 (RISC-V4F) Series
+config_registers:
+  - offset: 0x00
+    name: RDPR_USER
+    description: RDPR, nRDPR, USER, nUSER
+    reset: 0x00FF5AA5
+    fields:
+      - bit_range: [7, 0]
+        name: RDPR
+        description: Read Protection. 0xA5 for unprotected, otherwise read-protected(ignoring WRP)
+        explanation:
+          0xa5: Unprotected
+          _: Protected
+      # byte 2, [0:0] + 16
+      - bit_range: [16, 16]
+        name: IWDG_SW
+        description: Independent watchdog (IWDG) hardware enable
+        explanation:
+          1: IWDG enabled by the software, and disabled by hardware
+          0: IWDG enabled by the software (decided along with the LSI clock)
+      # [1:1] + 16
+      - bit_range: [17, 17]
+        name: STOP_RST
+        description: System reset control under the stop mode
+        explanation:
+          1: Disable
+          0: Enable
+      # [2:2] + 16
+      - bit_range: [18, 18]
+        name: STANDBY_RST
+        description: System reset control under the standby mode, STANDY_RST
+        explanation:
+          1: Disable, entering standby-mode without RST
+          0: Enable
+      # [7:6] + 16
+      - bit_range: [23, 22]
+        name: SRAM_CODE_MODE
+        description: SRAM Code Mode
+        explanation:
+          0b00: CODE-192KB + RAM-128KB
+          0b01: CODE-224KB + RAM-96KB
+          0b10: CODE-256KB + RAM-64KB
+          0b11: CODE-228KB + RAM-32KB
+  - offset: 0x04
+    name: DATA
+    description: Customizable 2 byte data, DATA0, nDATA0, DATA1, nDATA1
+    reset: 0xFF00FF00
+    type: u32
+    fields:
+      - bit_range: [7, 0]
+        name: DATA0
+      - bit_range: [23, 16]
+        name: DATA1
+  - offset: 0x08
+    name: WRP
+    # Each bit represents 4K bytes (16 pages) to store the write protection status
+    description: Flash memory write protection status
+    type: u32
+    reset: 0xFFFFFFFF
+    explanation:
+      0xFFFFFFFF: Unprotected
+      _: Some 4K sections are protected
+variants:
+  - name: CH32V317WCU6
+    chip_id: 0x73
+    flash_size: 256K
+  - name: CH32V307VCT6
+    chip_id: 0x70
+    flash_size: 256K

--- a/src/device.rs
+++ b/src/device.rs
@@ -163,6 +163,7 @@ impl ChipDB {
             serde_yaml::from_str(include_str!("../devices/0x23-CH32X03x.yaml"))?,
             serde_yaml::from_str(include_str!("../devices/0x24-CH643.yaml"))?,
             serde_yaml::from_str(include_str!("../devices/0x25-CH32L103.yaml"))?,
+            serde_yaml::from_str(include_str!("../devices/0x26-CH32V317.yaml"))?,
         ];
         for family in &families {
             family.validate()?;


### PR DESCRIPTION
Small additions to add support for CH32V317 chips. Based on the entries for CH32V307 since they are very similar.
Tested on CH32V317WCU6 (nanoCH32V317 board). Changing configuration bytes and flashing seem to work fine - I was able to unlock the chip and flash my own program.