### PR TITLE
ci: add only-when-changed to nightly-release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -155,6 +155,9 @@ jobs:
           name: "wchisp nightly release $$"
           draft: false
           prerelease: true
+          # Skip republishing when the nightly tag is already at HEAD — avoids
+          # spamming watchers with empty re-releases on cron runs.
+          only-when-changed: true
           body: |
             This is a nightly binary release of the wchisp command line tool.
           files: |


### PR DESCRIPTION
## Summary

- Add `only-when-changed: true` to the `andelf/nightly-release` step in the nightly CI job
- Skips re-publishing when the nightly tag is already at HEAD, preventing spurious release notifications to watchers on cron runs with no code changes

## Test plan

- [ ] Verify nightly CI run skips publish when HEAD hasn't changed
- [ ] Verify nightly CI run publishes when HEAD has new commits

Same fix as ch32-rs/wlink#107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)