### PR TITLE
fix: Check status byte for errors

### DIFF
--- a/src/flashing.rs
+++ b/src/flashing.rs
@@ -428,6 +428,16 @@ impl<'a> Flashing<'a> {
             .transport
             .transfer_with_wait(cmd, Duration::from_millis(300))?;
         anyhow::ensure!(resp.is_ok(), "program 0x{:08x} failed", address);
+        // The per-chunk Program result is carried in the response payload
+        // (payload[0]): 0x00 = ok, non-zero = rejected by the BootROM. Without
+        // this check a rejected Program is silently reported as a successful flash.
+        let status = resp.payload().first().copied().unwrap_or(0xff);
+        anyhow::ensure!(
+            status == 0x00,
+            "program 0x{:08x} rejected by BootROM (status 0x{:02x})",
+            address,
+            status
+        );
         Ok(())
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -322,7 +322,12 @@ impl Response {
         let status = raw[1];
         let len = raw.pread_with::<u16>(2, scroll::LE)? as usize;
         let remain = &raw[4..];
-        anyhow::ensure!(remain.len() == len, "Invalid response");
+        anyhow::ensure!(
+            remain.len() == len,
+            "Invalid response: expected payload len {}, got {}",
+            len,
+            remain.len()
+        );
         match status {
             0x00 | 0x82 => Ok(Response::Ok(remain.to_vec())),
             code => Ok(Response::Err(code, remain.to_vec())),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -314,17 +314,18 @@ impl Response {
     }
 
     pub(crate) fn from_raw(raw: &[u8]) -> Result<Self> {
-        // FIXME: should raw[1] == 0x00 || raw[1] == 0x82?
-        if true {
-            let len = raw.pread_with::<u16>(2, scroll::LE)? as usize;
-            let remain = &raw[4..];
-            if remain.len() == len {
-                Ok(Response::Ok(remain.to_vec()))
-            } else {
-                Err(anyhow::anyhow!("Invalid response"))
-            }
-        } else {
-            Ok(Response::Err(raw[1], raw[2..].to_vec()))
+        // Response layout: [cmd][status][len_lo][len_hi][payload...]. The status
+        // byte must be honored: previously the parser unconditionally returned
+        // Response::Ok for any correctly-framed response, masking error replies.
+        // 0x00 = ok; 0x82 has been observed as ok-with-data on some reads.
+        anyhow::ensure!(raw.len() >= 4, "Response too short");
+        let status = raw[1];
+        let len = raw.pread_with::<u16>(2, scroll::LE)? as usize;
+        let remain = &raw[4..];
+        anyhow::ensure!(remain.len() == len, "Invalid response");
+        match status {
+            0x00 | 0x82 => Ok(Response::Ok(remain.to_vec())),
+            code => Ok(Response::Err(code, remain.to_vec())),
         }
     }
 }


### PR DESCRIPTION
The ISP response parser and code-flash both ignored error status.  This allows a rejected operation to be reported as a successful.

- Response::from_raw() had `if true` returning Response::Ok for any correctly structured reply regardless of the status byte. Honour the status byte: 0x00 (OK) and 0x82 (OK with Data) -> Ok, anything else -> Err. Resolves the existing FIXME.
- flash_chunk() only checks the response structure, not the per chunk status byte carried in payload[0]. A rejected Program returns a reply with payload[0] != 0 which should be an error but was treated as s success.